### PR TITLE
upgrade pydantic to fix python 3.11 run issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+venv
+__pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ arrow
 fastapi==0.75.1
 supabase~=0.3.0
 python-dotenv~=0.19.2
-pydantic~=1.9.0
+pydantic~=1.10.0
 starlette~=0.17
 uvicorn
-pybgpkit==0.2.1
+pybgpkit==0.4.3

--- a/start-debug.sh
+++ b/start-debug.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+python3 -m venv venv
+pip3 install --upgrade pip
+pip3 install -r requirements.txt
+
 python3 -m uvicorn main:app --host 0.0.0.0 --reload


### PR DESCRIPTION
Python older pydantic version has compatibility issue with Python 3.11 (see comments [here](https://github.com/tiangolo/fastapi/issues/5048#issuecomment-1229183881)).

This PR updates the pydantic minimum version to 1.10.0 and also upgrades the `pybgpkit` to 0.4.3.

This PR also updates the `start-debug.sh` script to start the uvicorn process in virtual environment.

Related to #3.